### PR TITLE
Return username after login success

### DIFF
--- a/new_dawn_server/users/api/resources.py
+++ b/new_dawn_server/users/api/resources.py
@@ -82,8 +82,10 @@ class UserResource(ModelResource):
         if user:
             if user.is_active:
                 login(request, user)
+                # Return username and access token to store in iOS keychain
                 return self.create_response(request, {
                     "success": True,
+                    "username": user.username,
                     "token": user.api_key.key,
                 })
             else:

--- a/new_dawn_server/users/api/tests/test_users_api.py
+++ b/new_dawn_server/users/api/tests/test_users_api.py
@@ -99,5 +99,6 @@ class UserRegisterTest(ResourceTestCaseMixin, TestCase):
         res_data = json.loads(res.content)
         user = User.objects.get(username="test-user")
         self.assertEqual(res_data["success"], True)
+        self.assertEqual(res_data["username"], self.register_arguments["username"])
         self.assertEqual(res_data["token"], user.api_key.key)
 


### PR DESCRIPTION
Return username after login success
front-end will be able to store username & access token into key chain and reuse them to access the user's private data