### PR TITLE
[Like] Append Liked info applied to the viewer in profile GET response

### DIFF
--- a/new_dawn_server/actions/api/tests/test_like.py
+++ b/new_dawn_server/actions/api/tests/test_like.py
@@ -131,9 +131,9 @@ class UserActionTest(ResourceTestCaseMixin, TestCase):
             "/api/v1/profile/", format="json", data={"viewer_id": 1}
         )
         res_data = json.loads(res.content)
-        self.assertEqual(res_data["objects"][1]["liked_question"], "how are you")
-        self.assertEqual(res_data["objects"][1]["liked_entity_type"], 3)
-        self.assertEqual(res_data["objects"][1]["liked_answer"], "good")
+        self.assertEqual(res_data["objects"][1]["liked_info"]["liked_question"], "how are you")
+        self.assertEqual(res_data["objects"][1]["liked_info"]["liked_entity_type"], 3)
+        self.assertEqual(res_data["objects"][1]["liked_info"]["liked_answer"], "good")
 
     def test_match_user(self):
         self.api_client.post(

--- a/new_dawn_server/actions/api/tests/test_like.py
+++ b/new_dawn_server/actions/api/tests/test_like.py
@@ -67,6 +67,19 @@ class UserActionTest(ResourceTestCaseMixin, TestCase):
                         "country": "US",
                         "state": "UT"
                     }
+                ],
+            "answer_question":
+                [
+                    {
+                        "question": "how are you",
+                        "order": 1,
+                        "answer": "good",
+                    },
+                    {
+                        "question": "How do you do",
+                        "order": 2,
+                        "answer": "do do"
+                    }
                 ]
         }
         self.api_client.post(
@@ -80,6 +93,14 @@ class UserActionTest(ResourceTestCaseMixin, TestCase):
             "entity_type": EntityType.MAIN_IMAGE.value,
             "user_from": "1",
             "user_to": "2"
+        }
+
+        self.like_argument_2 = {
+            "action_type": ActionType.LIKE.value,
+            "entity_id": 1,
+            "entity_type": EntityType.QUESTION_ANSWER.value,
+            "user_from": "2",
+            "user_to": "1"
         }
 
     def test_like_user(self):
@@ -101,6 +122,18 @@ class UserActionTest(ResourceTestCaseMixin, TestCase):
         self.assertEqual(test_like_object.entity_type, EntityType.MAIN_IMAGE.value)
         self.assertEqual(test_like_object.entity_id, 1)
         self.assertEqual(test_like_object.user_to.username, "duck2")
+
+    def test_viewer_liked_info_fetched_from_profile(self):
+        res = self.api_client.post(
+            "/api/v1/user_action/", format="json", data=self.like_argument_2
+        )
+        res = self.api_client.get(
+            "/api/v1/profile/", format="json", data={"viewer_id": 1}
+        )
+        res_data = json.loads(res.content)
+        self.assertEqual(res_data["objects"][1]["liked_question"], "how are you")
+        self.assertEqual(res_data["objects"][1]["liked_entity_type"], 3)
+        self.assertEqual(res_data["objects"][1]["liked_answer"], "good")
 
     def test_match_user(self):
         self.api_client.post(

--- a/new_dawn_server/management/commands/create_test_actions.py
+++ b/new_dawn_server/management/commands/create_test_actions.py
@@ -7,6 +7,17 @@ from new_dawn_server.actions.models import UserAction
 
 class Command(BaseCommand):
 
+    def create_like(self, a, b):
+        # Create Match
+        print(f"Like from {a} to {b}")
+        UserAction.objects.create(
+            action_type = ActionType.LIKE.value,
+            entity_id = 1,
+            entity_type = EntityType.MAIN_IMAGE.value,
+            user_from = User.objects.get(id=a),
+            user_to = User.objects.get(id=b)
+        )
+
     def create_match(self, a, b):
         # Create Match
         print(f"Relationship between {a} and {b}")
@@ -32,6 +43,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         print("Create User Actions")
+        self.create_like(4,1)
         self.create_match(1,2)
         self.create_match(1,3)
         self.create_message(1,2,"Hey there!")

--- a/new_dawn_server/users/api/resources.py
+++ b/new_dawn_server/users/api/resources.py
@@ -6,9 +6,13 @@ from django.conf.urls import url
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import User
 from django.db import transaction
+from django.db.models import Q
 from django.db.models import signals
+from new_dawn_server.actions.constants import ActionType, EntityType
+from new_dawn_server.actions.models import UserAction
 from new_dawn_server.locations.api.resources import CityResource
 from new_dawn_server.locations.models import CityPreference
+from new_dawn_server.medias.models import Image
 from new_dawn_server.modules.client_response import ClientResponse
 from new_dawn_server.questions.models import AnswerQuestion, Question
 from new_dawn_server.users.models import Account
@@ -245,9 +249,33 @@ class ProfileResource(ModelResource):
         else:
             return None
 
+    def _get_liker_info(self, bundle):
+        # TODO: Refactor this out to become a standalone module
+        viewer_id = bundle.request.GET.get('viewer_id')
+        user_id = bundle.data["user"].data["id"]
+        likes = UserAction.objects.filter(
+            Q(user_from__id__exact=user_id) 
+            & Q(user_to__id__exact=viewer_id) 
+            & Q(action_type=ActionType.LIKE.value)
+        )
+        if len(likes) > 0:
+            like_obj = likes[len(likes)-1]
+            bundle.data["liked_entity_type"] = like_obj.entity_type
+            bundle.data["liked_message"] = like_obj.message
+            if like_obj.entity_type == EntityType.MAIN_IMAGE.value:
+                image_obj = Image.objects.get(id=like_obj.entity_id)
+                bundle.data["liked_image_url"] = image_obj.media
+            if like_obj.entity_type == EntityType.QUESTION_ANSWER.value:
+                answer_question_obj = AnswerQuestion.objects.get(id=like_obj.entity_id)
+                bundle.data["liked_question"] = answer_question_obj.question.question
+                bundle.data["liked_answer"] = answer_question_obj.answer
+            
+            
+
     # Add Answer question fields in Profile Resource
     def dehydrate(self, bundle):
         bundle.data['age'] = self._get_age(bundle.data['account'].data['birthday'])
+        self._get_liker_info(bundle)
         return bundle
 
 

--- a/new_dawn_server/users/api/resources.py
+++ b/new_dawn_server/users/api/resources.py
@@ -260,7 +260,7 @@ class ProfileResource(ModelResource):
             & Q(action_type=ActionType.LIKE.value)
         )
         if likes.count():
-            like_obj = likes[len(likes)-1]
+            like_obj = likes[likes.count()-1]
             liked_dict = {
                 "liked_entity_type": like_obj.entity_type,
                 "liked_message": like_obj.message,

--- a/new_dawn_server/users/api/resources.py
+++ b/new_dawn_server/users/api/resources.py
@@ -260,15 +260,18 @@ class ProfileResource(ModelResource):
         )
         if len(likes) > 0:
             like_obj = likes[len(likes)-1]
-            bundle.data["liked_entity_type"] = like_obj.entity_type
-            bundle.data["liked_message"] = like_obj.message
+            liked_dict = {
+                "liked_entity_type": like_obj.entity_type,
+                "liked_message": like_obj.message,
+            }
             if like_obj.entity_type == EntityType.MAIN_IMAGE.value:
                 image_obj = Image.objects.get(id=like_obj.entity_id)
-                bundle.data["liked_image_url"] = image_obj.media
+                liked_dict["liked_image_url"] = image_obj.media
             if like_obj.entity_type == EntityType.QUESTION_ANSWER.value:
                 answer_question_obj = AnswerQuestion.objects.get(id=like_obj.entity_id)
-                bundle.data["liked_question"] = answer_question_obj.question.question
-                bundle.data["liked_answer"] = answer_question_obj.answer
+                liked_dict["liked_question"] = answer_question_obj.question.question
+                liked_dict["liked_answer"] = answer_question_obj.answer
+            bundle.data["liked_info"] = liked_dict
             
             
 

--- a/new_dawn_server/users/api/resources.py
+++ b/new_dawn_server/users/api/resources.py
@@ -15,6 +15,7 @@ from new_dawn_server.locations.models import CityPreference
 from new_dawn_server.medias.models import Image
 from new_dawn_server.modules.client_response import ClientResponse
 from new_dawn_server.questions.models import AnswerQuestion, Question
+from new_dawn_server.settings import MEDIA_URL
 from new_dawn_server.users.models import Account
 from new_dawn_server.users.models import Profile
 from tastypie import fields
@@ -258,7 +259,7 @@ class ProfileResource(ModelResource):
             & Q(user_to__id__exact=viewer_id) 
             & Q(action_type=ActionType.LIKE.value)
         )
-        if len(likes) > 0:
+        if likes.count():
             like_obj = likes[len(likes)-1]
             liked_dict = {
                 "liked_entity_type": like_obj.entity_type,
@@ -266,7 +267,7 @@ class ProfileResource(ModelResource):
             }
             if like_obj.entity_type == EntityType.MAIN_IMAGE.value:
                 image_obj = Image.objects.get(id=like_obj.entity_id)
-                liked_dict["liked_image_url"] = image_obj.media
+                liked_dict["liked_image_url"] = MEDIA_URL + str(image_obj.media)
             if like_obj.entity_type == EntityType.QUESTION_ANSWER.value:
                 answer_question_obj = AnswerQuestion.objects.get(id=like_obj.entity_id)
                 liked_dict["liked_question"] = answer_question_obj.question.question


### PR DESCRIPTION
Dehydrate like action info for the viewer so that the profile response can include some extra fields indicating how the user liked the viewer.

Add some tests and commands

<img width="457" alt="Screen Shot 2019-03-19 at 10 36 52 PM" src="https://user-images.githubusercontent.com/8229754/54655231-88f84580-4a97-11e9-973b-636cd4fce7a8.png">

