### PR TITLE
Replace images when update

### DIFF
--- a/new_dawn_server/users/api/resources.py
+++ b/new_dawn_server/users/api/resources.py
@@ -25,6 +25,7 @@ from tastypie.authentication import (
     BasicAuthentication,
     MultiAuthentication
 )
+import os
 from tastypie.authorization import Authorization
 from tastypie.exceptions import BadRequest
 from tastypie.http import HttpForbidden, HttpNotAcceptable, HttpNoContent, HttpUnauthorized
@@ -393,6 +394,15 @@ class UserRegisterResource(ModelResource):
         user_bundle = super(UserRegisterResource, self).obj_update(bundle, **kwargs)
         Profile.objects.get(user=user_bundle.obj).delete()
         Account.objects.get(user=user_bundle.obj).delete()
+        existing_imgs = Image.objects.filter(user=user_bundle.obj)
+        for existing_img in existing_imgs:
+            file = existing_img.media.path
+            # Remove the uploaded file
+            try:
+                os.remove(file)
+            except OSError:
+                pass
+        Image.objects.filter(user=user_bundle.obj).delete()
         account = Account(
             user=user_bundle.obj,
             name=self._get_account_name(user_bundle.obj.first_name, user_bundle.obj.last_name),


### PR DESCRIPTION
When update profile, new images will be updated/ persist exited images in profile.

Video in slack.